### PR TITLE
Replace "beatles" with "beetle"

### DIFF
--- a/word_list.go
+++ b/word_list.go
@@ -226,7 +226,7 @@ var WordList = []string{
 	"alias", "ambient", "andy", "anvil", "appear", "apropos",
 	"archer", "ariel", "armor", "arrow", "austin", "avatar",
 	"axis", "baboon", "bahama", "bali", "balsa", "bazooka",
-	"beach", "beast", "beatles", "beauty", "before", "benny",
+	"beach", "beast", "beauty", "beetle", "before", "benny",
 	"betty", "between", "beyond", "billy", "bison", "blast",
 	"bless", "bogart", "bonanza", "book", "border", "brave",
 	"bread", "break", "broken", "bucket", "buenos", "buffalo",


### PR DESCRIPTION
I noticed the word "beatles", as in the band, is on the original Mnemonicode list. I imagine someone speaking this word would almost certainly have to take the time to specify "Beatles as in the band, not beetles the bugs". 

In an attempt to fix this, I replaced it with the word "beetle", which I think is less ambiguous (but obviously similar to the replaced word). 

I'm submitting this PR both as a suggested improvement, but also as a question of important is it to keep [the original mnemonicode list](https://github.com/singpolyma/mnemonicode/blob/master/mn_wordlist.c) unchanged for this project and those that rely upon it. 